### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/src/modules/llms/server/openai/openai.router.ts
+++ b/src/modules/llms/server/openai/openai.router.ts
@@ -561,8 +561,15 @@ export function openAIAccess(access: OpenAIAccessSchema, modelRefId: string | nu
       const oaiOrg = access.oaiOrg || env.OPENAI_API_ORG_ID || '';
       let oaiHost = fixupHost(access.oaiHost || env.OPENAI_API_HOST || DEFAULT_OPENAI_HOST, apiPath);
       // warn if no key - only for default (non-overridden) hosts
-      if (!oaiKey && oaiHost.indexOf(DEFAULT_OPENAI_HOST) !== -1)
-        throw new Error('Missing OpenAI API Key. Add it on the UI or server side (your deployment).');
+      try {
+        const parsedHost = new URL(oaiHost).host;
+        const allowedHosts = [DEFAULT_OPENAI_HOST, `api.${DEFAULT_OPENAI_HOST}`];
+        if (!oaiKey && allowedHosts.includes(parsedHost)) {
+          throw new Error('Missing OpenAI API Key. Add it on the UI or server side (your deployment).');
+        }
+      } catch (e) {
+        throw new Error('Invalid OpenAI API Host. Please check the API Host field in the Models Setup page.');
+      }
 
       // [Helicone]
       // We don't change the host (as we do on Anthropic's), as we expect the user to have a custom host.


### PR DESCRIPTION
Potential fix for [https://github.com/TheJ-Erk400/big-AGI-dev/security/code-scanning/5](https://github.com/TheJ-Erk400/big-AGI-dev/security/code-scanning/5)

To fix the issue, we need to replace the substring check (`oaiHost.indexOf(DEFAULT_OPENAI_HOST) !== -1`) with a more secure validation method. Specifically, we should:

1. Parse the `oaiHost` string into a URL object using the `URL` constructor.
2. Extract the `host` property from the parsed URL.
3. Compare the extracted host against a whitelist of allowed hosts (e.g., `DEFAULT_OPENAI_HOST` and its valid subdomains).

This approach ensures that only valid hosts are accepted, preventing malicious URLs from bypassing the check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Improve sanitization of user-provided OpenAI host by parsing the URL, verifying the host against a whitelist, and handling invalid hosts explicitly to address code-scanning alert.

Enhancements:
- Replace substring-based host validation with URL parsing and exact host whitelist matching
- Add explicit error handling for malformed or disallowed OpenAI host URLs