### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/modules/llms/server/anthropic/anthropic.router.ts
+++ b/src/modules/llms/server/anthropic/anthropic.router.ts
@@ -115,7 +115,9 @@ export function anthropicAccess(access: AnthropicAccessSchema, antModelIdForBeta
   // https://docs.helicone.ai/getting-started/integration-method/anthropic
   const heliKey = access.heliconeKey || env.HELICONE_API_KEY || false;
   if (heliKey) {
-    if (!anthropicHost.includes(DEFAULT_ANTHROPIC_HOST) && !anthropicHost.includes(DEFAULT_HELICONE_ANTHROPIC_HOST))
+    const parsedHost = new URL(anthropicHost).host;
+    const allowedHosts = [DEFAULT_ANTHROPIC_HOST, DEFAULT_HELICONE_ANTHROPIC_HOST];
+    if (!allowedHosts.includes(parsedHost))
       throw new Error(`The Helicone Anthropic Key has been provided, but the host is set to custom. Please fix it in the Models Setup page.`);
     anthropicHost = `https://${DEFAULT_HELICONE_ANTHROPIC_HOST}`;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/TheJ-Erk400/big-AGI-dev/security/code-scanning/4](https://github.com/TheJ-Erk400/big-AGI-dev/security/code-scanning/4)

To fix the issue, the code should parse the `anthropicHost` URL and validate its host component against a whitelist of allowed hosts. This ensures that the host is explicitly checked and cannot be bypassed by embedding the allowed host as a substring in other parts of the URL.

Steps to implement the fix:
1. Use the `URL` class to parse the `anthropicHost` string and extract its `host` component.
2. Replace the substring check (`includes`) with a whitelist validation using `DEFAULT_ANTHROPIC_HOST` and `DEFAULT_HELICONE_ANTHROPIC_HOST`.
3. Update the logic to throw an error if the host is not in the whitelist.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Parse anthropicHost with the URL class and validate its host against a whitelist of allowed hosts, throwing an error for custom hosts to address a code scanning alert

Bug Fixes:
- Fix incomplete URL substring sanitization by strictly validating the host component of anthropicHost against an allowed whitelist

Enhancements:
- Refactor anthropicHost validation to use the URL class and direct host matching instead of substring includes